### PR TITLE
Fix typo emtiData -> emitData

### DIFF
--- a/src/server/Uploader.js
+++ b/src/server/Uploader.js
@@ -81,12 +81,12 @@ class Uploader {
   }
 
   emitSuccess (url) {
-    const emtiData = {
+    const emitData = {
       action: 'success',
       payload: { complete: true, url }
     }
-    this.saveState(emtiData)
-    emitter.emit(this.token, emtiData)
+    this.saveState(emitData)
+    emitter.emit(this.token, emitData)
   }
 
   uploadTus () {


### PR DESCRIPTION
While debugging I found a minor typo in `src/server/Uploader.js`: `emitData` is accidently spelled `emtiData`.

Absolutely not important but I thought why not fixing it :)