### PR TITLE
Add repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "author": "Transloadit.com",
   "license": "ISC",
   "homepage": "https://github.com/transloadit/uppy-server#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/transloadit/uppy-server.git"
+  },
   "keywords": [
     "file uploader",
     "progress",


### PR DESCRIPTION
This will add a link to the Github repository from the npm package page.

(The `homepage` key, surprisingly, does not add a link…)