### PR TITLE
Configurable S3 key

### DIFF
--- a/src/server/controllers/s3.js
+++ b/src/server/controllers/s3.js
@@ -4,7 +4,8 @@ const S3 = require('aws-sdk/clients/s3')
 
 const defaultConfig = {
   acl: 'public-read',
-  conditions: []
+  conditions: [],
+  getKey: (req, filename) => filename
 }
 
 module.exports = function s3 (config) {
@@ -17,15 +18,17 @@ module.exports = function s3 (config) {
 
   return router()
     .get('/params', (req, res, next) => {
+      const key = config.getKey(req, req.query.filename)
+      const fields = {
+        acl: config.acl,
+        key: key,
+        success_action_status: '201',
+        'content-type': req.query.type
+      }
       client.createPresignedPost({
         Bucket: config.bucket,
         Expires: ms('5 minutes') / 1000,
-        Fields: {
-          acl: config.acl,
-          key: req.query.filename,
-          success_action_status: '201',
-          'content-type': req.query.type
-        },
+        Fields: fields,
         Conditions: config.conditions
       }, (err, data) => {
         if (err) {

--- a/src/server/controllers/s3.js
+++ b/src/server/controllers/s3.js
@@ -10,6 +10,14 @@ const defaultConfig = {
 
 module.exports = function s3 (config) {
   config = Object.assign({}, defaultConfig, config)
+
+  if (typeof config.acl !== 'string') {
+    throw new TypeError('s3: The `acl` option must be a string')
+  }
+  if (typeof config.getKey !== 'function') {
+    throw new TypeError('s3: The `getKey` option must be a function')
+  }
+
   const client = new S3({
     region: config.region,
     accessKeyId: config.key,
@@ -19,12 +27,17 @@ module.exports = function s3 (config) {
   return router()
     .get('/params', (req, res, next) => {
       const key = config.getKey(req, req.query.filename)
+      if (typeof key !== 'string') {
+        return res.status(500).json({ error: 's3: filename returned from `getKey` must be a string' })
+      }
+
       const fields = {
         acl: config.acl,
         key: key,
         success_action_status: '201',
         'content-type': req.query.type
       }
+
       client.createPresignedPost({
         Bucket: config.bucket,
         Expires: ms('5 minutes') / 1000,


### PR DESCRIPTION
Users can provide a `getKey` function option to set the file's upload
path.
The `getKey` option receives the http request instance `req`, and the
original `filename`. The `req` can be used to set the path to an
authenticated user's subdirectory, for example:

```js
app.use(authenticationMiddleware)
app.use(uppy.app({
  s3: {
    getKey: (req, filename) => `${req.user.id}/${filename}`,
    /* auth options */
  }
}))
```

Or we can return something that doesn't include the original filename at
all, like a UUID:

```js
const path = require('path')
const uuid = require('uuid')
app.use(uppy.app({
  s3: {
    getKey: (req, filename) => `${uuid.v4()}${path.extname(filename)}`
  }
}))
```

Ref: transloadit/uppy#236 (comment)

---

There are many more ways to configure S3 uploads, but this is a good one to start with 😄 