### PR TITLE
Pass multipart form fields to upload endpoint

### DIFF
--- a/src/server/Uploader.js
+++ b/src/server/Uploader.js
@@ -220,7 +220,11 @@ class Uploader {
       this.emitProgress(bytesUploaded, null)
     })
 
-    const formData = { [this.options.fieldname]: file }
+    const formData = Object.assign(
+      {},
+      this.options.metadata,
+      { [this.options.fieldname]: file }
+    )
     request.post({ url: this.options.endpoint, formData }, (error, response, body) => {
       if (error || response.statusCode >= 400) {
         console.error(`error: ${error} status: ${response ? response.statusCode : null}`)


### PR DESCRIPTION
Send the custom form fields defined by the Uppy client along to the
upload endpoint. Allows eg. the AwsS3 plugin to work for remote files.

Fixes https://github.com/transloadit/uppy-server/issues/57

Tested using files from Google Drive & uploading to S3 using the AwsS3 plugin.