### PR TITLE
Support tus uploadUrl parameter.

### DIFF
--- a/src/server/Uploader.js
+++ b/src/server/Uploader.js
@@ -162,6 +162,7 @@ class Uploader {
     // @ts-ignore
     this.tus = new tus.Upload(file, {
       endpoint: this.options.endpoint,
+      uploadUrl: this.options.uploadUrl,
       resume: true,
       uploadSize: this.options.size || fs.statSync(this.options.path).size,
       metadata,


### PR DESCRIPTION
Allows uploading to a tus endpoint if you don't actually get to create
your own upload, like with Vimeo's upload API.

In the future we should make `endpoint` optional, which involves
changing a bunch of checks throughout the Uploader class, but we can't
do that yet because tus-js-client still requires an endpoint currently.