### PR TITLE
Fix passing the uploadUrl to Uploader

### DIFF
--- a/src/server/controllers/get.js
+++ b/src/server/controllers/get.js
@@ -27,6 +27,7 @@ function get (req, res) {
     req.uppy.debugLog('Instantiating uploader.')
     const uploader = new Uploader({
       endpoint: body.endpoint,
+      uploadUrl: body.uploadUrl,
       protocol: body.protocol,
       metadata: body.metadata,
       size: size,

--- a/src/server/controllers/url.js
+++ b/src/server/controllers/url.js
@@ -55,6 +55,7 @@ const get = (req, res) => {
       req.uppy.debugLog('Instantiating uploader.')
       const uploader = new Uploader({
         endpoint: req.body.endpoint,
+        uploadUrl: req.body.uploadUrl,
         protocol: req.body.protocol,
         metadata: req.body.metadata,
         size: size,


### PR DESCRIPTION
Actually pass the uploadUrl to the Uploader instance, to make #65 work.