### PR TITLE
Configurable endpoint

### DIFF
--- a/env.example.sh
+++ b/env.example.sh
@@ -32,6 +32,7 @@ export UPPYSERVER_INSTAGRAM_SECRET="***"
 export UPPYSERVER_AWS_KEY="***"
 export UPPYSERVER_AWS_SECRET="***"
 export UPPYSERVER_AWS_BUCKET="***"
+export UPPYSERVER_AWS_ENDPOINT="https://s3.{region}.amazonaws.com"
 export UPPYSERVER_AWS_REGION="***"
 
 # source env.sh

--- a/src/server/controllers/s3.js
+++ b/src/server/controllers/s3.js
@@ -4,6 +4,7 @@ const S3 = require('aws-sdk/clients/s3')
 
 const defaultConfig = {
   acl: 'public-read',
+  endpoint: 'https://{service}.{region}.amazonaws.com',
   conditions: [],
   getKey: (req, filename) => filename
 }
@@ -20,6 +21,7 @@ module.exports = function s3 (config) {
 
   const client = new S3({
     region: config.region,
+    endpoint: config.endpoint,
     accessKeyId: config.key,
     secretAccessKey: config.secret
   })

--- a/src/standalone/helper.js
+++ b/src/standalone/helper.js
@@ -44,6 +44,7 @@ const getConfigFromEnv = () => {
         key: process.env.UPPYSERVER_AWS_KEY,
         secret: process.env.UPPYSERVER_AWS_SECRET,
         bucket: process.env.UPPYSERVER_AWS_BUCKET,
+        endpoint: process.env.UPPYSERVER_AWS_ENDPOINT,
         region: process.env.UPPYSERVER_AWS_REGION
       }
     },


### PR DESCRIPTION
Per discussion in https://github.com/transloadit/uppy/pull/663.

This extends the current approach with an `AWS_ENDPOINT` environment
variable that you can use to configure the S3 endpoint. The AWS SDK
helpfully supports endpoints in this template format so regions can
still be specified as a separate variable:

    https://{region}.digitaloceanspaces.com

As mentioned in transloadit/uppy#663 we may need something more flexible
in the future so you don't have to run a separate server for every
bucket or w/e, but this is a low-effort way to support S3 alternatives
for now, which I think is worth something.

Tested by running the [aws-uppy-server](https://github.com/transloadit/uppy/tree/master/aws-uppy-server) example with only an added
`endpoint: 'https://{region}.digitaloceanspaces.com'` in `server.js`.

![image](https://user-images.githubusercontent.com/1006268/36671814-6866eb7a-1afd-11e8-8827-8ef7bf3aaf60.png)
