### PR TITLE
Pass headers to upload endpoint

### DIFF
--- a/src/server/Uploader.js
+++ b/src/server/Uploader.js
@@ -9,6 +9,7 @@ const serializeError = require('serialize-error')
 const { jsonStringify, hasMatch } = require('./utils')
 const logger = require('./logger')
 const validator = require('validator')
+const headerSanitize = require('./header-blacklist')
 
 class Uploader {
   /**
@@ -24,7 +25,7 @@ class Uploader {
    * @property {object=} storage
    * @property {string=} path
    * @property {object=} s3
-   * @property {object} headers
+   * @property {object=} headers
    *
    * @param {UploaderOptions} options
    */
@@ -289,7 +290,8 @@ class Uploader {
       this.options.metadata,
       { [this.options.fieldname]: file }
     )
-    request.post({ url: this.options.endpoint, headers: this.options.headers, formData, encoding: null }, (error, response, body) => {
+    const headers = headerSanitize(this.options.headers)
+    request.post({ url: this.options.endpoint, headers, formData, encoding: null }, (error, response, body) => {
       if (error) {
         logger.error(error, 'upload.multipart.error')
         this.emitError(error)

--- a/src/server/Uploader.js
+++ b/src/server/Uploader.js
@@ -24,6 +24,7 @@ class Uploader {
    * @property {object=} storage
    * @property {string=} path
    * @property {object=} s3
+   * @property {object} headers
    *
    * @param {UploaderOptions} options
    */
@@ -288,7 +289,7 @@ class Uploader {
       this.options.metadata,
       { [this.options.fieldname]: file }
     )
-    request.post({ url: this.options.endpoint, formData, encoding: null }, (error, response, body) => {
+    request.post({ url: this.options.endpoint, headers: this.options.headers, formData, encoding: null }, (error, response, body) => {
       if (error) {
         logger.error(error, 'upload.multipart.error')
         this.emitError(error)

--- a/src/server/controllers/get.js
+++ b/src/server/controllers/get.js
@@ -25,7 +25,8 @@ function get (req, res) {
       s3: req.uppy.s3Client ? {
         client: req.uppy.s3Client,
         options: providerOptions.s3
-      } : null
+      } : null,
+      headers: body.headers
     })
 
     // wait till the client has connected to the socket, before starting

--- a/src/server/controllers/url.js
+++ b/src/server/controllers/url.js
@@ -57,7 +57,8 @@ const get = (req, res) => {
         metadata: req.body.metadata,
         size: size,
         pathPrefix: `${filePath}`,
-        storage: redisUrl ? redis.createClient({ url: redisUrl }) : null
+        storage: redisUrl ? redis.createClient({ url: redisUrl }) : null,
+        headers: req.body.headers
       })
 
       req.uppy.debugLog('Waiting for socket connection before beginning remote download.')

--- a/src/server/header-blacklist.js
+++ b/src/server/header-blacklist.js
@@ -1,0 +1,64 @@
+const isObject = require('isobject')
+const logger = require('./logger')
+
+/**
+ * Forbidden header names.
+ */
+const forbiddenNames = [
+  'accept-charset',
+  'accept-encoding',
+  'access-control-request-headers',
+  'access-control-request-method',
+  'connection',
+  'content-length',
+  'cookie',
+  'cookie2',
+  'date',
+  'dnt',
+  'expect',
+  'host',
+  'keep-alive',
+  'origin',
+  'referer',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+  'via'
+]
+
+/**
+ * Forbidden header regexs.
+ */
+const forbiddenRegex = [/^proxy-.*$/, /^sec-.*$/]
+
+/**
+ * Check if the header in parameter is a forbidden header.
+ * @param {*} header Header to check
+ * @return True if header is forbidden, false otherwise.
+ */
+const isForbiddenHeader = (header) => {
+  const headerLower = header.toLowerCase()
+  const forbidden =
+    forbiddenNames.indexOf(headerLower) >= 0 ||
+    forbiddenRegex.findIndex((regex) => regex.test(headerLower)) >= 0
+
+  if (forbidden) {
+    logger.warn(`Header forbbiden: ${header}`, 'header.forbidden')
+  }
+  return forbidden
+}
+
+module.exports = (headers) => {
+  if (!isObject(headers)) {
+    return {}
+  }
+
+  const headersCloned = Object.assign({}, headers)
+  Object.keys(headersCloned).forEach((header) => {
+    if (isForbiddenHeader(header)) {
+      delete headersCloned[header]
+    }
+  })
+  return headersCloned
+}

--- a/test/__tests__/header-blacklist.js
+++ b/test/__tests__/header-blacklist.js
@@ -1,0 +1,58 @@
+/* global test:false, expect:false, describe:false, */
+
+const headerSanitize = require('../../src/server/header-blacklist')
+
+describe('Header black-list testing', () => {
+  test('All headers invalid by name', () => {
+    const headers = headerSanitize({
+      origin: 'http://www.google.com',
+      'Accept-Charset': '...',
+      'content-Length': 1234
+    })
+
+    expect(headers).toEqual({})
+  })
+
+  test('All headers invalid by regex', () => {
+    const headers = headerSanitize({
+      'Proxy-header-fake': 'proxy-header-fake',
+      'proxy-header-fake-lower': 'proxy-header-fake-lower',
+      'proxy-': 'proxy-header-fake-empty',
+      'Sec-': 'sec-header-empty',
+      'sec-': 'sec-lower-header-empty',
+      'Sec-header-fake': 'sec-header-fake',
+      'sec-header-fake': 'sec-header-fake'
+    })
+    expect(headers).toEqual({})
+  })
+
+  test('All headers invalid by name and regex', () => {
+    const headers = headerSanitize({
+      'Proxy-header-fake': 'proxy-header-fake',
+      'Sec-header-fake': 'sec-header-fake'
+    })
+    expect(headers).toEqual({})
+  })
+
+  test('Returning only allowed headers', () => {
+    const headers = headerSanitize({
+      Authorization: 'Basic Xxxxxx',
+      'Content-Type': 'application/json',
+      'Content-Length': 1234,
+      Expires: 'Wed, 21 Oct 2015 07:28:00 GMT',
+      Origin: 'http://www.google.com'
+    })
+    expect(Object.keys(headers)).toHaveLength(3)
+    expect(headers).toHaveProperty('Authorization')
+    expect(headers).toHaveProperty('Content-Type')
+    expect(headers).toHaveProperty('Expires')
+  })
+
+  test('Return empty object when headers is not an object', () => {
+    expect(headerSanitize({})).toEqual({})
+    expect(headerSanitize(null)).toEqual({})
+    expect(headerSanitize(undefined)).toEqual({})
+    expect(headerSanitize('Authorization: Basic 1234')).toEqual({})
+    expect(headerSanitize(['Authorization', 'Basic 1234'])).toEqual({})
+  })
+})


### PR DESCRIPTION
The purpose of this PR is make **uppy-server** be able to pass request headers configured in _uppy XHR_ to upload endpoint.

There are a lot of use cases that need of this feature (authorizations, refer, and so on..).

Nowadays, the headers already are sended to providers endpoints but is not passed to upload endpoint.

This discussion was started in uppy project, follow the link: [https://github.com/transloadit/uppy/issues/779](url)
