### PR TITLE
Fix redis chart arguments in kubernetes docs

### DIFF
--- a/KUBERNETES.md
+++ b/KUBERNETES.md
@@ -7,9 +7,9 @@ kubectl create ns uppy
 We will need a Redis container that we can get through [helm](https://github.com/kubernetes/helm)
 
 ```bash
- helm install --name uppy \
+ helm install --name redis \
   --namespace uppy \
-  --set redisPassword=superSecretPassword \
+  --set password=superSecretPassword \
     stable/redis
 ```
 


### PR DESCRIPTION
The redis chart password argument is called `password` now [[docs](https://github.com/kubernetes/charts/tree/master/stable/redis#configuration)].