### PR TITLE
Fix multipart upload run

### DIFF
--- a/src/server/Uploader.js
+++ b/src/server/Uploader.js
@@ -102,7 +102,9 @@ class Uploader {
     // The download has completed; close the file and start an upload if necessary.
     if (chunk === null) {
       if (this.options.endpoint && protocol === 'multipart') {
-        this.uploadMultipart()
+        this.writer.on('finish', () => {
+          this.uploadMultipart()
+        })
       }
       return this.writer.end()
     }


### PR DESCRIPTION
Run multipart upload in the **finish** event handler of write stream to avoid partial file uploading.

Old code run uploading before stream **end** method run. This generates the UPLOAD_ERR_PARTIAL error on PHP server from time to time.