### PR TITLE
Add type to metadata as `filetype` for tusd

### DIFF
--- a/src/server/Uploader.js
+++ b/src/server/Uploader.js
@@ -221,7 +221,8 @@ class Uploader {
 
   uploadTus () {
     const fname = path.basename(this.options.path)
-    const metadata = Object.assign({ filename: fname }, this.options.metadata || {})
+    const ftype = this.options.metadata.type
+    const metadata = Object.assign({ filename: fname, filetype: ftype }, this.options.metadata || {})
     const file = fs.createReadStream(this.options.path)
     const uploader = this
 


### PR DESCRIPTION
In Uppy Client we did this:

> tus: add `filename` and `filetype`, so that tus servers knows what headers to set  https://github.com/tus/tus-js-client/commit/ebc5189eac35956c9f975ead26de90c896dbe360 (#844 / @vith)

See https://github.com/transloadit/uppy/pull/844 for more details.